### PR TITLE
upgrade to latest expo sdk 28

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "description": "An empty new project",
     "slug": "expo-sqlite-example",
     "privacy": "public",
-    "sdkVersion": "24.0.0",
+    "sdkVersion": "28.0.0",
     "version": "1.0.0",
     "orientation": "portrait",
     "primaryColor": "#cccccc",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "main": "node_modules/expo/AppEntry.js",
   "dependencies": {
-    "expo": "24.0.0",
-    "react": "16.0.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz"
+    "expo": "^28.0.0",
+    "react": "16.3.1",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-28.0.0.tar.gz"
   }
 }


### PR DESCRIPTION
updated to use the latest version of expo sdk 28: https://blog.expo.io/expo-sdk-v28-0-0-is-now-available-f30e8253b530